### PR TITLE
Technical debt: remove max_workers, document null handling

### DIFF
--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -1,0 +1,40 @@
+---
+title: PR Summary - Technical debt cleanup (max_workers removal, null handling docs)
+tags: [breaking, documentation]
+---
+
+## Overview
+
+- **Removed unused `max_workers`** from ExactMatcher, Matcher, and Deduplicator so the API matches reality (Polars handles parallelization; the parameter was never used).
+- **Documented null handling** for exact matching: Polars inner joins exclude nulls (including null-to-null); docstring and README updated so behavior is explicit.
+- **ROADMAP** updated: technical debt items marked done and Next Steps checkboxes updated.
+
+## Key Changes
+
+### Matching Algorithm
+
+- `matcher/algorithms.py`:
+  - ExactMatcher no longer accepts `max_workers`; class docstring notes Polars handles parallelization.
+  - ExactMatcher.match() docstring documents null handling: join keys with nulls (including null-to-null) are excluded; suggests filling/dropping nulls if different behavior is needed.
+
+### Matcher and Deduplicator
+
+- `matcher/matcher.py`:
+  - Matcher no longer accepts `max_workers`; algorithm initialization simplified (no hasattr/pass-through).
+- `matcher/deduplicator.py`:
+  - Deduplicator no longer accepts or passes `max_workers` to Matcher.
+
+### Documentation
+
+- `README.md`:
+  - New **Null handling** subsection after Quick Start describing exact-match null behavior and when to preprocess nulls.
+- `ROADMAP.md`:
+  - Technical debt items 1 (Remove max_workers) and 2 (Document null handling) marked ✅ Done; corresponding Next Steps checkboxes checked.
+
+## Testing
+
+- All existing tests passing: `pytest` (47 tests). No test code changes; removal of `max_workers` is backward-incompatible for callers who passed it (they will get `TypeError: unexpected keyword argument 'max_workers'`).
+
+---
+
+**Note:** Add GitHub labels to the PR (e.g. `breaking`, `documentation`) so release notes can categorize this correctly.

--- a/README.md
+++ b/README.md
@@ -52,22 +52,22 @@ pip install hygge-match
 
 ```python
 import polars as pl
-from matcher import Matcher
+from matcher import Matcher, Deduplicator
 
 # Load data (you load DataFrames, matcher operates on them)
 left_df = pl.read_parquet("data/ExactMatcher/entity_resolution/customers_a.parquet")
 right_df = pl.read_parquet("data/ExactMatcher/entity_resolution/customers_b.parquet")
 
 # Entity resolution (using default components)
-matcher = Matcher(left=left_df, right=right_df)
+matcher = Matcher(left=left_df, right=right_df, left_id="id", right_id="id")
 results = matcher.match(rules="email")
 print(f"Found {results.count} matches")
 results.matches.head(10)
 
 # Deduplication (single source)
 df = pl.read_parquet("data/ExactMatcher/deduplication/customers.parquet")
-matcher = Matcher(left=df)
-results = matcher.match(rules="email")
+deduplicator = Deduplicator(source=df, id_col="id")
+results = deduplicator.match(rules="email")
 print(f"Found {results.count} duplicate pairs")
 
 # Multiple matching rules (OR logic)
@@ -77,6 +77,10 @@ results = matcher.match(rules=[
     ["first_name", "last_name"]
 ])
 ```
+
+### Null handling
+
+Exact matching uses Polars inner joins. Rows where any join key (e.g. `email`, `first_name`) is null are excluded from matches—including null-to-null. Fill or drop nulls in your match columns beforehand if you need different behavior.
 
 ## Data-Driven Development Philosophy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # hygge-match Roadmap
 
-**Last Updated:** 2024
+**Last Updated:** 2025
 **Current Phase:** Phase 1 Complete ✅
 **Next Phase:** TBD (Phase 2 Blocking or Phase 3 Fuzzy Matching)
 
@@ -55,7 +55,7 @@
 
 ### Priority: Medium
 
-#### 1. Remove `max_workers` Parameter
+#### 1. Remove `max_workers` Parameter ✅ Done
 
 **Issue:** Parameter exists but is not used. Polars handles parallelization internally.
 
@@ -76,7 +76,7 @@
 
 ### Priority: Low
 
-#### 2. Document Null Handling
+#### 2. Document Null Handling ✅ Done
 
 **Issue:** Polars inner joins exclude null values by default, but this behavior is not documented.
 
@@ -385,8 +385,8 @@ Simplify when:
 ## Next Steps
 
 1. **Immediate (This Week)**
-   - [ ] Remove `max_workers` parameter
-   - [ ] Document null handling behavior
+   - [x] Remove `max_workers` parameter
+   - [x] Document null handling behavior
    - [ ] Review roadmap with stakeholders
 
 2. **Short-term (Next 1-3 months)**

--- a/matcher/algorithms.py
+++ b/matcher/algorithms.py
@@ -22,7 +22,6 @@ Design Notes:
 
 import polars as pl
 from polars import DataFrame
-from typing import Optional
 from abc import ABC, abstractmethod
 
 
@@ -57,16 +56,14 @@ class MatchingAlgorithm(ABC):
 
 
 class ExactMatcher(MatchingAlgorithm):
-    """Exact matching algorithm for entity resolution."""
+    """Exact matching algorithm for entity resolution.
 
-    def __init__(self, max_workers: Optional[int] = None):
-        """Initialize ExactMatcher.
+    Parallelization is handled internally by Polars (joins are parallelized).
+    """
 
-        Args:
-            max_workers: Maximum number of parallel workers for operations within a rule.
-                        Defaults to None (uses CPU count). Set to 1 to disable parallelization.
-        """
-        self.max_workers = max_workers
+    def __init__(self):
+        """Initialize ExactMatcher."""
+        pass
 
     def match(
         self,
@@ -78,6 +75,10 @@ class ExactMatcher(MatchingAlgorithm):
     ) -> DataFrame:
         """Exact matching via inner join on field(s) for a single rule.
 
+        Null handling: Polars inner joins exclude null values. Rows where any
+        join key is null do not match (including null-to-null). Fill or drop
+        nulls in join columns beforehand if you need different behavior.
+
         Args:
             left: Left source DataFrame
             right: Right source DataFrame
@@ -87,7 +88,9 @@ class ExactMatcher(MatchingAlgorithm):
             right_id: Column name for right source ID
 
         Returns:
-            DataFrame with matches for this rule, including left_id and {right_id}_right columns
+            DataFrame with matches for this rule, including left_id and {right_id}_right columns.
+            When a join key equals right_id, Polars may not add a separate right_id_right column;
+            this method adds it so the result always includes right_id_right for evaluation.
         """
         # Normalize to format expected by Polars join
         if len(rule) == 1:
@@ -98,7 +101,8 @@ class ExactMatcher(MatchingAlgorithm):
         # Join left and right on specified field(s)
         result = left.join(right, on=field, how="inner", suffix="_right")
 
-        # Ensure right_id_right exists for evaluation (if right_id column exists in right)
+        # When a join key equals right_id, Polars may not add right_id_right; add it so
+        # the result always has right_id_right for evaluation.
         right_id_right = f"{right_id}_right"
         if right_id in right.columns and right_id_right not in result.columns:
             # Add right_id_right by joining on the field(s) again

--- a/matcher/deduplicator.py
+++ b/matcher/deduplicator.py
@@ -53,18 +53,15 @@ class Deduplicator:
         self,
         source: DataFrame,
         id_col: str,
-        matching_algorithm: Optional[MatchingAlgorithm] = None,
-        max_workers: Optional[int] = None
+        matching_algorithm: Optional[MatchingAlgorithm] = None
     ):
         """Initialize deduplicator with a single source DataFrame.
 
         Args:
             source: Polars DataFrame (in-memory) - MUST have id_col column
             id_col: Column name for source ID
-            matching_algorithm: MatchingAlgorithm component (default: ExactMatcher)
-            max_workers: Maximum number of parallel workers for operations within a rule.
-                        Only used if the matching algorithm supports it (e.g., ExactMatcher).
-                        Defaults to None (uses CPU count). Set to 1 to disable parallelization.
+            matching_algorithm: MatchingAlgorithm component (default: ExactMatcher).
+                               Polars handles parallelization internally for joins.
 
         Raises:
             ValueError: If source DataFrame doesn't have the specified ID column
@@ -75,8 +72,7 @@ class Deduplicator:
             right=source.clone(),
             left_id=id_col,
             right_id=id_col,
-            matching_algorithm=matching_algorithm,
-            max_workers=max_workers
+            matching_algorithm=matching_algorithm
         )
         self._id_col = id_col
 

--- a/matcher/matcher.py
+++ b/matcher/matcher.py
@@ -58,8 +58,7 @@ class Matcher:
         right: DataFrame,
         left_id: str,
         right_id: str,
-        matching_algorithm: Optional[MatchingAlgorithm] = None,
-        max_workers: Optional[int] = None
+        matching_algorithm: Optional[MatchingAlgorithm] = None
     ):
         """Initialize matcher with Polars DataFrames.
 
@@ -68,10 +67,8 @@ class Matcher:
             right: Polars DataFrame (in-memory) - MUST have right_id column
             left_id: Column name for left source ID
             right_id: Column name for right source ID
-            matching_algorithm: MatchingAlgorithm component (default: ExactMatcher)
-            max_workers: Maximum number of parallel workers for operations within a rule.
-                        Only used if the matching algorithm supports it (e.g., ExactMatcher).
-                        Defaults to None (uses CPU count). Set to 1 to disable parallelization.
+            matching_algorithm: MatchingAlgorithm component (default: ExactMatcher).
+                               Polars handles parallelization internally for joins.
 
         Raises:
             ValueError: If left or right DataFrames don't have the specified ID column
@@ -100,14 +97,10 @@ class Matcher:
         self.left = left
         self.right = right
 
-        # Initialize matching algorithm with max_workers if not provided and algorithm supports it
         if matching_algorithm is None:
-            self.matching_algorithm = ExactMatcher(max_workers=max_workers)
+            self.matching_algorithm = ExactMatcher()
         else:
             self.matching_algorithm = matching_algorithm
-            # If algorithm supports max_workers and it's not set, set it
-            if hasattr(self.matching_algorithm, 'max_workers') and max_workers is not None:
-                self.matching_algorithm.max_workers = max_workers
 
     def match(
         self,


### PR DESCRIPTION
## Overview

- **Removed unused `max_workers`** from ExactMatcher, Matcher, and Deduplicator so the API matches reality (Polars handles parallelization; the parameter was never used).
- **Documented null handling** for exact matching: Polars inner joins exclude nulls (including null-to-null); docstring and README updated so behavior is explicit.
- **README Quick Start** fixed: entity resolution uses `left_id`/`right_id`; deduplication uses `Deduplicator(source=..., id_col=...)` so examples run as-is.
- **ROADMAP** updated: technical debt items marked done, Next Steps checkboxes checked, Last Updated set to 2025.

## Key Changes

### Matching Algorithm

- `matcher/algorithms.py`:
  - ExactMatcher no longer accepts `max_workers`; class docstring notes Polars handles parallelization.
  - ExactMatcher.match() docstring documents null handling and when/why `right_id_right` is added (join key equals right_id case); inline comment aligned.

### Matcher and Deduplicator

- `matcher/matcher.py`: Matcher no longer accepts `max_workers`; algorithm initialization simplified (no hasattr/pass-through).
- `matcher/deduplicator.py`: Deduplicator no longer accepts or passes `max_workers` to Matcher.

### Documentation

- `README.md`: New **Null handling** subsection; Quick Start now uses `Matcher(..., left_id="id", right_id="id")` and `Deduplicator(source=df, id_col="id")` so snippets match the real API.
- `ROADMAP.md`: Technical debt items 1 and 2 marked ✅ Done; Next Steps checkboxes updated; **Last Updated** set to 2025.

## Testing

- All existing tests passing: `pytest` (47 tests). Removal of `max_workers` is backward-incompatible for callers who passed it (`TypeError: unexpected keyword argument 'max_workers'`).

---
*Labels: `breaking`, `documentation`*