### PR TITLE
 Fix exact matcher right-id fallback

### DIFF
--- a/matcher/algorithms.py
+++ b/matcher/algorithms.py
@@ -143,9 +143,9 @@ class ExactMatcher(MatchingAlgorithm):
         right_id_right = f"{right_id}_right"
         if right_id in right.columns and right_id_right not in result.columns:
             # Add right_id_right by joining on the field(s) again
+            join_cols = [field] if isinstance(field, str) else field
             right_ids = right.select(
-                [field] if isinstance(field, str) else field,
-                pl.col(right_id).alias(right_id_right)
+                [*join_cols, pl.col(right_id).alias(right_id_right)]
             )
             result = result.join(right_ids, on=field, how="left", suffix="_temp")
             # Clean up if we got a temp column

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -711,6 +711,63 @@ def test_match_with_blocking_key_same_results():
     assert without.matches["id_right"].to_list() == with_blocking.matches["id_right"].to_list()
 
 
+def test_exact_match_with_distinct_left_right_ids_and_blocking():
+    """Regression: exact match works when left/right IDs differ and block_on is used.
+
+    This mirrors ContactAttributes-style matching where:
+    - left_id is ContactId
+    - right_id is PatientId
+    - join key is AttributeValue
+    - blocking key is BlockKey
+
+    Previously this hit a ColumnNotFoundError in ExactMatcher's fallback path
+    that ensures `{right_id}_right` exists in the result.
+    """
+    left = pl.DataFrame({
+        "ContactId": ["1"],
+        "AttributeType": ["address"],
+        "AttributeValue": ["123 main st"],
+        "FirstNameNormalized": ["john"],
+        "LastNameNormalized": ["doe"],
+        "BlockKey": ["60601"],
+        "NameInitial": ["J"],
+        "SourceRecordId": ["left-1"],
+        "SourceIdColumn": ["ContactId"],
+    })
+    right = pl.DataFrame({
+        "PatientAttributeId": ["pa-1"],
+        "PatientId": ["9"],
+        "GuarantorId": ["g-1"],
+        "IsMinor": [False],
+        "IsGuarantorContact": [False],
+        "AttributeType": ["address"],
+        "AttributeValue": ["123 main st"],
+        "FirstNameNormalized": ["john"],
+        "LastNameNormalized": ["doe"],
+        "BlockKey": ["60601"],
+        "NameInitial": ["J"],
+        "SourceRecordId": ["right-1"],
+        "SourceIdColumn": ["PatientId"],
+    })
+
+    matcher = Matcher(
+        left=left.filter(pl.col("AttributeType") == "address"),
+        right=right.filter(pl.col("AttributeType") == "address"),
+        left_id="ContactId",
+        right_id="PatientId",
+    )
+
+    results = matcher.match(match_on="AttributeValue", block_on="BlockKey")
+
+    assert results.count == 1
+    assert "PatientId_right" in results.matches.columns
+    row = results.matches.select("ContactId", "PatientId_right", "AttributeValue", "BlockKey").to_dicts()[0]
+    assert row["ContactId"] == "1"
+    assert row["PatientId_right"] == "9"
+    assert row["AttributeValue"] == "123 main st"
+    assert row["BlockKey"] == "60601"
+
+
 def test_match_with_blocking_key_no_common_blocks():
     """When left and right share no blocking key value, no matches."""
     left = pl.DataFrame({


### PR DESCRIPTION
## Overview

- Fixed a regression in exact matching when `left_id` and `right_id` differ and `block_on` is used.
- Prevented `ColumnNotFoundError` caused by malformed intermediate join columns in `ExactMatcher`.
- Added a regression test that mirrors ContactAttributes-style matching (`ContactId` ↔ `PatientId`).

## Key Changes

### Exact Matching Reliability

- `matcher/algorithms.py`:
  - Updated the right-id fallback selection in `ExactMatcher.match()` to build join columns safely for single-field and multi-field rules.
  - Replaced ambiguous `right.select(...)` construction with explicit flattened column list, preserving the expected join key columns.
  - Fix ensures `{right_id}_right` can be added without breaking follow-up joins under blocking.

### Regression Coverage

- `tests/test_core.py`:
  - Added `test_exact_match_with_distinct_left_right_ids_and_blocking()`.
  - Covers real-world schema shape with:
    - left id: `ContactId`
    - right id: `PatientId`
    - match key: `AttributeValue`
    - block key: `BlockKey`
  - Verifies successful match plus presence and correctness of `PatientId_right`.

### Impact

- Eliminates a confusing runtime error path and restores expected behavior for blocked exact matching with non-identical id column names.
- Improves reliability for notebook-driven ER workflows using narrow attribute tables.

## Testing

- Targeted regression test passing:
  - `uv run python -m pytest tests/test_core.py -k distinct_left_right_ids_and_blocking -q`
- Result: `1 passed` (targeted run).

**PR labels:** Add `bug` and `fix` for release notes categorization.
